### PR TITLE
Fixed a crash happening when forced unwrapping optional value

### DIFF
--- a/LiterateSwift/RenderViewController.swift
+++ b/LiterateSwift/RenderViewController.swift
@@ -86,8 +86,8 @@ class RenderViewController: NSViewController {
     }
 
     override func viewDidAppear() {
-        if let doc = view.window?.windowController?.document as? MarkdownDocument {
-            let fileName = doc.fileURL!.path!
+        if let doc = view.window?.windowController?.document as? MarkdownDocument, let fileName = doc.fileURL?.path {
+            
             let load = self.loadNode(fileName)
             doc.callbacks.append(load)
             load(elements: doc.elements)


### PR DESCRIPTION
It happens when you open the App, then click on a tab **without** first selecting a file
